### PR TITLE
Don't assume that the input being validated is a string

### DIFF
--- a/src/australianBusinessNumber.js
+++ b/src/australianBusinessNumber.js
@@ -12,6 +12,9 @@ angular.module('australianBusinessNumber', [])
 				}
 				
 				var isValid = false;
+				
+				val = val.toString();
+				
 				val = val.replace(/\s/g, '');
 	
 				// 0. ABN must be 11 digits long


### PR DESCRIPTION
An integer value will throw an error. Convert to a string before performing regex
